### PR TITLE
Add port 80 and 32768-61000, split rules out into resources.

### DIFF
--- a/assessments/cloud-platform-engineer/iac/main.tf
+++ b/assessments/cloud-platform-engineer/iac/main.tf
@@ -1,28 +1,36 @@
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+
 resource "aws_security_group" "bymiles-security-group" {
   description = "A security group"
-  vpc_id      = "vpc-bb571bd3"
+  vpc_id      = "${aws_vpc.main.id}"
   name        = "bymiles-security-group"
+}
 
-  ingress {
-    protocol  = "tcp"
-    from_port = 32768
-    to_port   = 61000
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+resource "aws_security_group_rule" "http" {
+  security_group_id = "${aws_security_group.bymiles-security-group.id}"
+  type              = "ingress"
+  protocol          = "TCP"
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "ingress" {
   security_group_id = "${aws_security_group.bymiles-security-group.id}"
   type              = "ingress"
   protocol          = "TCP"
-  from_port         = 80
-  to_port           = 80
+  from_port         = 32768
+  to_port           = 61000
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "egress" {
+  security_group_id = "${aws_security_group.bymiles-security-group.id}"
+  type              = "egress"
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 0
   cidr_blocks       = ["0.0.0.0/0"]
 }


### PR DESCRIPTION
Co-authored-by: Matt Tortolani <matt@doodlemoonch.com>

## What

* Add port 80 and 32768 - 61000

## Steps to deploy
- [ ] Run `terraform plan --out plan`
- [ ] Run `terraform apply` 

## Steps to validate
> Any manual validation steps required

- [ ] Validate rules are created in console
- [ ] Re-run terraform plan and apply and ensure no new resources created

## Risks
> Could block access to resources within the VPC

## Steps to rollback
> Comment out resources and re-run plan/apply
